### PR TITLE
[KTB-28] sysn to personal repo 액션 추가

### DIFF
--- a/.github/workflows/sync-to-personal-repo.yml
+++ b/.github/workflows/sync-to-personal-repo.yml
@@ -1,0 +1,34 @@
+name: Sync to Personal Repo
+
+on:
+  push:
+    branches:
+      - develop
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout source repository
+        uses: actions/checkout@v2
+        with:
+          repository: ktb6/ktb6-teamblog
+          ref: develop
+
+      - name: Configure Git
+        run: |
+          git config --global user.name 'Danny-Jo'
+          git config --global user.email 'dannyjo.world@gmail.com'
+
+      - name: Add remote repository
+        run: |
+          git remote add personal https://github.com/Danny-Jo/ktb6-teamblog-mirror.git
+          git fetch personal
+          git rebase personal/main
+
+      - name: Push changes
+        env:
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+        run: |
+          git push personal develop --force


### PR DESCRIPTION
# KTB-28 sysn to personal repo 액션 추가

## 🎯 목적
* vercel에서 무료로 호스팅을 하기 위해서는 개인 계정의 repo를 사용해야 합니다. organization의 repo를 개인 계정을 복사하는 과정을 자동화 시키는 액션을 추가하여 개인 계정 repo와 organization repo를 동기화 시킵니다.


## ✅ 작업 내용
* [x] sysn to personal repo 파일 추가